### PR TITLE
Add missing imports to __init__.py

### DIFF
--- a/ovos_lang_detector_fasttext_plugin/__init__.py
+++ b/ovos_lang_detector_fasttext_plugin/__init__.py
@@ -2,6 +2,7 @@ from ovos_plugin_manager.templates.language import LanguageDetector
 from langcodes import standardize_tag
 from ovos_plugin_manager.templates.language import LanguageDetector
 from huggingface_hub import hf_hub_download
+import fasttext
 
 
 class FastTextLangDetectPlugin(LanguageDetector):

--- a/ovos_lang_detector_fasttext_plugin/__init__.py
+++ b/ovos_lang_detector_fasttext_plugin/__init__.py
@@ -1,6 +1,7 @@
 from ovos_plugin_manager.templates.language import LanguageDetector
 from langcodes import standardize_tag
 from ovos_plugin_manager.templates.language import LanguageDetector
+from huggingface_hub import hf_hub_download
 
 
 class FastTextLangDetectPlugin(LanguageDetector):


### PR DESCRIPTION
The \_\_init\_\_.py was missing the following imports:
```python
from huggingface_hub import hf_hub_download
import fasttext
```

That caused the following errors:
```
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/ovos-translate-server", line 8, in <module>
    sys.exit(main())
  File "/home/ubuntu/.local/lib/python3.10/site-packages/ovos_translate_server/__main__.py", line 26, in main
    start_translate_server(args.tx_engine, args.detect_engine, port=args.port, host=args.host)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/ovos_translate_server/__init__.py", line 74, in start_translate_server
    DETECT = engine(config=cfg.get(detect_engine, {}))
  File "/home/ubuntu/.local/lib/python3.10/site-packages/ovos_lang_detector_fasttext_plugin/__init__.py", line 11, in __init__
    model_path = hf_hub_download(repo_id="facebook/fasttext-language-identification", filename="model.bin")
NameError: name 'hf_hub_download' is not defined
```
and
```
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/ovos-translate-server", line 8, in <module>
    sys.exit(main())
  File "/home/ubuntu/.local/lib/python3.10/site-packages/ovos_translate_server/__main__.py", line 26, in main
    start_translate_server(args.tx_engine, args.detect_engine, port=args.port, host=args.host)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/ovos_translate_server/__init__.py", line 74, in start_translate_server
    DETECT = engine(config=cfg.get(detect_engine, {}))
  File "/home/ubuntu/.local/lib/python3.10/site-packages/ovos_lang_detector_fasttext_plugin/__init__.py", line 13, in __init__
    self.lid = fasttext.load_model(model_path)
NameError: name 'fasttext' is not defined
```

Adding the imports fixed the errors