### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,40 @@
 # FastText Language Identification
 
-[fasttext-language-identification](https://huggingface.co/facebook/fasttext-language-identification) is the companion language detector for the [NLLB](https://github.com/facebookresearch/fairseq/blob/nllb/README.md#lid-model) model
+This plugin identifies the language of a text with the [fasttext-language-identification](https://huggingface.co/facebook/fasttext-language-identification) model. Facebook AI Research trained this model as a companion to [NLLB](https://github.com/facebookresearch/fairseq/blob/nllb/README.md#lid-model). The plugin downloads the model from the Hugging Face Hub on first use.
 
+## Install
 
-## Configuration
+```bash
+pip install ovos-lang-detector-fasttext-plugin
+```
 
-in `mycroft.conf` 
+## Usage
+
+Set this plugin as the language detection module in `mycroft.conf`:
 
 ```javascript
   "language": {
     "detection_module": "ovos-lang-detector-fasttext-plugin"
   },
 ```
+
+You can also call the plugin directly:
+
+```python
+from ovos_lang_detector_fasttext_plugin import FastTextLangDetectPlugin
+
+clf = FastTextLangDetectPlugin()
+print(clf.detect("olá mundo"))
+print(clf.detect_probs("olá mundo"))
+```
+
+`detect` returns the most likely language code. `detect_probs` returns the top 5 language codes with their probabilities.
+
+## Related projects
+
+- [OpenVoiceOS/ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): defines the `LanguageDetector` template this plugin implements.
+- [facebookresearch/fairseq](https://github.com/facebookresearch/fairseq/blob/nllb/README.md#lid-model): the NLLB project, source of the underlying language identification model.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README for clarity: adds an install section, a direct usage example alongside the config snippet, and links to related OpenVoiceOS projects. Keeps every existing fact and the license.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with installation and configuration instructions.
  * Added examples for direct Python usage and explanations of detection outputs.
  * Included related projects and Apache-2.0 license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->